### PR TITLE
Prevent paste processing on middle click

### DIFF
--- a/the-one-true-todey-file-of-cellpond.js
+++ b/the-one-true-todey-file-of-cellpond.js
@@ -54,6 +54,14 @@ A: it's a secret
 
 */
 
+var middleClicked = false
+
+document.addEventListener('mousedown', function(event) {
+    if (event.button === 1) {
+        middleClicked = true
+    }
+})
+
 const urlParams = new URLSearchParams(window.location.search)
 const NO_SECRET_MODE = urlParams.has("nosecret")
 const NO_FOOLS_MODE = urlParams.has("nofools")
@@ -9253,6 +9261,11 @@ registerRule(
 	}
 
 	const unpackPaddles = (pack) => {
+	    	if (middleClicked) {
+	        	middleClicked = false
+	        	return
+	    	}
+
 		loadedColour = false
 		unlockMenuTool("triangle")
 		unlockMenuTool("circle")


### PR DESCRIPTION
This will prevent processing the paste if the middle click is clicked. It doesn't outright remove the pasting functionality, but pressing `Ctrl + V` or `Cmd + V` accidentally is more difficult anyway.

With this change, the site doesn't error out on middle-clicking on Linux - the only thing that happens is that, if the click is in the field, a dot gets placed.

Fixes #304. Tested on the affected system.