### PR TITLE
fix: make save work without native API

### DIFF
--- a/the-one-true-todey-file-of-cellpond.js
+++ b/the-one-true-todey-file-of-cellpond.js
@@ -9559,7 +9559,7 @@ registerRule(
 			}
 		} else {
 			// Fallback to the Blob and link method
-			const blob = new Blob([JSON.stringify(pack)], {type: 'application/json'});
+			const blob = new Blob([pack], {type: 'application/json'});
 			const url = URL.createObjectURL(blob);
 
 			const link = document.createElement('a');


### PR DESCRIPTION
Makes the fallback not double JSON-stringify, fixing saves made like that.