### PR TITLE
Add info on saving to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ It's a secret.
 
 ## How do I save my creations?
 You can press ctrl/cmd+s to save your paddles to a file, and ctrl/cmd+o to load from a file.
+
 You can also use ctrl/cmd+c and ctrl/cmd+v to save and load from your clipboard!
 
 ## Where's the diamond gone?

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Or, you can [download the source code](https://github.com/TodePond/CellPond/arch
 It's a secret.
 
 ## How do I save my creations?
-You can press ctrl/cmd+s to save your paddles to a file, and ctrl/cmd+o to load from a file.
+You can use ctrl/cmd+s to save your paddles to a file, and ctrl/cmd+o to load from a file.
 
 You can also use ctrl/cmd+c and ctrl/cmd+v to save and load from your clipboard!
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ Or, you can [download the source code](https://github.com/TodePond/CellPond/arch
 ## How does it work? What do all the shapes do?
 It's a secret.
 
+## How do I save my creations?
+You can press ctrl/cmd+s to save your paddles to a file, and ctrl/cmd+o to load from a file.
+You can also use ctrl/cmd+c and ctrl/cmd+v to save and load from your clipboard!
+
 ## Where's the diamond gone?
 
 There used to be a diamond shape! It let you add/subtract/swap channels. But I rewrote a lot of stuff for the [Spellular Automata](https://youtu.be/xvlsJ3FqNYU) video and it broke.


### PR DESCRIPTION
Adds a section about how to save in the readme, as this would be useful for people new to CellPond to know and isn't really explained anywhere currently