### PR TITLE
multi-squares in multi-squares in ...

### DIFF
--- a/the-one-true-todey-file-of-cellpond.js
+++ b/the-one-true-todey-file-of-cellpond.js
@@ -1395,29 +1395,67 @@ on.load(() => {
 		const [diagramWidth, diagramHeight] = getDiagramDimensions(diagram)
 		const widthScale = cell.width / diagramWidth
 		const heightScale = cell.height / diagramHeight
+		
+		const diagramCells = getOrderedCellAtoms(diagram.left)
+		const dimX = Math.round(diagramWidth/diagramCells[0].width)
+		const dimY = Math.round(diagramHeight/diagramCells[0].height)
 
 		const children = []
-		for (const diagramCell of diagram.left) {
+		const addedChildren = []
+		
+		let i = 0
+		for (let x = 0; x < dimX; x++) {
+			for (let y = 0; y < dimY; y++) {
+				let diagramCell = diagramCells[i]
+				
+				if (diagramCell === undefined || (diagramCell.x+128 != x*diagramWidth/dimX+128) || (diagramCell.y+128 != y*diagramHeight/dimY+128)){
+					const red = makeNumber({values: [true, true, true, true, true, true, true, true, true, true], channel: 0})
+					const green = makeNumber({values: [true, true, true, true, true, true, true, true, true, true], channel: 1})
+					const blue = makeNumber({values: [true, true, true, true, true, true, true, true, true, true], channel: 2})
+					const emptyCell = makeArray({channels: [red, green, blue]})
+					diagramCell = makeDiagramCell({
+						x: x*diagramWidth/dimX,
+						y: y*diagramHeight/dimY,
+						width: diagramWidth/dimX,
+						height: diagramHeight/dimY,
+						content: emptyCell,
+					})
+				} else {
+					i++
+				}
+				
+				if (diagramCell.content.isDiagram){
+					const cellToSplit = makeCell({
+						x: cell.x + diagramCell.x * widthScale,
+						y: cell.y + diagramCell.y * heightScale,
+						width: diagramCell.width * widthScale,
+						height: diagramCell.height * heightScale,
+						colour: cell.colour,
+					})
+					addCell(cellToSplit)
+					addedChildren.push(...splitCellToDiagram(cellToSplit,diagramCell.content))
+				} else {
+					const colours = getSplashesArrayFromArray(diagramCell.content, {source: cell.colour})
+					const colour = colours[Random.Uint32 % colours.length]
 
-			const colours = getSplashesArrayFromArray(diagramCell.content, {source: cell.colour})
-			const colour = colours[Random.Uint32 % colours.length]
+					const child = makeCell({
+						x: cell.x + diagramCell.x * widthScale,
+						y: cell.y + diagramCell.y * heightScale,
+						width: diagramCell.width * widthScale,
+						height: diagramCell.height * heightScale,
+						colour: colour,
+					})
 
-			const child = makeCell({
-				x: cell.x + diagramCell.x * widthScale,
-				y: cell.y + diagramCell.y * heightScale,
-				width: diagramCell.width * widthScale,
-				height: diagramCell.height * heightScale,
-				colour: colour,
-			})
-
-			children.push(child)
+					children.push(child)
+				}
+			}
 		}
 
 		deleteCell(cell)
 		for (const child of children) {
 			addCell(child)
 		}
-
+		children.push(...addedChildren)
 		return children
 
 	}
@@ -8251,6 +8289,8 @@ registerRule(
 		return orderedCellAtoms
 	}
 
+
+	
 	const makeDiagramCellsFromCellAtoms = (cellAtoms) => {
 
 		const orderedCellAtoms = getOrderedCellAtoms(cellAtoms)
@@ -8270,6 +8310,75 @@ registerRule(
 		return diagramCells
 
 	}
+	
+	//adds diagram to list assuming every cell is the same size
+	const addDiagramCellsToRuleList = (diagramCells, list, stampeds, posX, posY, addSplit = false, sizeX=1, sizeY=1) => {
+		// Check for every mini-cell
+		let miniCount = 0
+		let addCount = 0
+		const orderedMiniLeftCells = getOrderedCellAtoms(diagramCells)
+
+		const dimX = Math.round(1/orderedMiniLeftCells[0].width)
+		const dimY = Math.round(1/orderedMiniLeftCells[0].height)
+		
+		if(addSplit){
+			const splitCell = makeDiagramCell({
+				x: posX,
+				y: posY,
+				width: sizeX,
+				height: sizeY,
+				instruction: DRAGON_INSTRUCTION.split,
+				splitX: dimX,
+				splitY: dimY,
+			})
+
+			list.push(splitCell)
+		}
+				
+		for (let x = 0; x < dimX; x++) {
+			for (let y = 0; y < dimY; y++) {				
+				const miniDiagramCell = orderedMiniLeftCells[addCount]
+				
+				const miniX = posX + x/dimX*sizeX
+				const miniY = posY + y/dimY*sizeY
+				const miniWidth = sizeX/dimX
+				const miniHeight = sizeY/dimY
+				
+				let miniClone
+				//pads not filled spaces
+				if (miniDiagramCell === undefined || (miniDiagramCell.x+128 != x/dimX+128) || (miniDiagramCell.y+128 != y/dimY+128)){
+					const red = makeNumber({values: [true, true, true, true, true, true, true, true, true, true], channel: 0})
+					const green = makeNumber({values: [true, true, true, true, true, true, true, true, true, true], channel: 1})
+					const blue = makeNumber({values: [true, true, true, true, true, true, true, true, true, true], channel: 2})
+					miniClone = makeArray({channels: [red, green, blue]})
+					
+					
+				} else {
+					addCount++
+					if (miniDiagramCell.content.isDiagram){
+						miniCount+= addDiagramCellsToRuleList(miniDiagramCell.content.left, list, stampeds, miniX, miniY, addSplit, miniWidth, miniHeight)
+						continue
+					} else{
+						miniClone = cloneDragonArray(miniDiagramCell.content)
+					}
+				}
+				
+				applyRangeStamp(stampeds, miniClone)
+				const diagramCell = makeDiagramCell({
+					x: miniX,
+					y: miniY,
+					width: miniWidth,
+					height: miniHeight,
+					content: miniClone,
+					instruction: DRAGON_INSTRUCTION.recolour,
+				})
+				list.push(diagramCell)
+			}
+		}
+		miniCount+= dimX*dimY
+		return miniCount
+	}
+	
 
 	const updatePaddleRule = (paddle) => {
 
@@ -8322,24 +8431,8 @@ registerRule(
 				left.push(diagramCell)
 
 			} else if (cellAtom.value.isDiagram) {
-
-				// Check for every mini-cell
-				const orderedMiniLeftCells = getOrderedCellAtoms(cellAtom.value.left)
-				for (const miniDiagramCell of orderedMiniLeftCells) {
-					const miniClone = cloneDragonArray(miniDiagramCell.content)
-					applyRangeStamp(stampeds, miniClone)
-					const miniX = x + miniDiagramCell.x
-					const miniY = y + miniDiagramCell.y
-					const diagramCell = makeDiagramCell({
-						x: miniX,
-						y: miniY,
-						width: miniDiagramCell.width,
-						height: miniDiagramCell.height,
-						content: miniClone,
-					})
-					left.push(diagramCell)
-					miniCount++
-				}
+				// Check for every mini-cell	
+				miniCount+= addDiagramCellsToRuleList(cellAtom.value.left, left, stampeds, x, y)
 
 			} else {
 				
@@ -8379,8 +8472,8 @@ registerRule(
 						x,
 						y,
 						instruction: DRAGON_INSTRUCTION.merge,
-						splitX: maxiWidth,
-						splitY: maxiHeight,
+						splitX: 1,
+						splitY: miniCount,
 					})
 	
 					right.push(mergeCell)
@@ -8398,39 +8491,11 @@ registerRule(
 				right.push(nothingCell)
 
 			} else if (rightContent.isDiagram) {
-
+			
 				// Split the cell into mini-cells!
-				const maxiRight = makeMaximisedDiagram(rightContent)
-				const [maxiWidth, maxiHeight] = getDiagramDimensions(maxiRight)
-				
-				const splitCell = makeDiagramCell({
-					x,
-					y,
-					instruction: DRAGON_INSTRUCTION.split,
-					splitX: maxiWidth,
-					splitY: maxiHeight,
-				})
-
-				right.push(splitCell)
-
 				// Recolour every mini-cell!
-				const orderedMiniRightCells = getOrderedCellAtoms(rightContent.left)
-				for (const miniDiagramCell of orderedMiniRightCells) {
-					const miniClone = cloneDragonArray(miniDiagramCell.content)
-					applyRangeStamp(stampeds, miniClone)
-					const miniX = x + miniDiagramCell.x
-					const miniY = y + miniDiagramCell.y
-					const diagramCell = makeDiagramCell({
-						x: miniX,
-						y: miniY,
-						width: miniDiagramCell.width,
-						height: miniDiagramCell.height,
-						content: miniClone,
-						instruction: DRAGON_INSTRUCTION.recolour,
-					})
-					right.push(diagramCell)
-				}
-
+				addDiagramCellsToRuleList(rightContent.left, right, stampeds, x, y, true)
+				
 			} else {
 
 				// Just recolour a single cell


### PR DESCRIPTION
Did this a while ago, but wanted to find a neater solution. Didn't find one and forgot to do it so ill just PR it now if you want to use it.

I did:
- #161 But only when the multi-square gets used (brush and rule update) so i could have missed cases. Did it that way because i don't like the way it looks.
- Made multi-squares in multi-squares work with brush and rules on left and right side. This fixes: #163  / #215 and kind of #322 (only fixes that that setup doesn't error in the rule update and not what it does when it errors)



Stuff i am not happy with/ is janky:
- The merge instruction merges m∗n cells. When i want to merge this: ⊞⊟ it isn't m∗n. Because the merge instruction is inplemented by merging next m∗n cells, i just tell it to merge n∗1 cells (6∗1 in the case of ⊞⊟).
- I implemented almost the same thing three times. 
  - `flattenAndFillDiagramCells` it flattens nested cells and fills the voids.
  - `addDiagramCellsToLeftList` it does the same but for rule gen on the left side. Also it returns what structure the nested cell had.
  - `addDiagramCellsToRightList` it does the same but  for rule gen on the right side and it uses the structure to tell when merge/split
- Because the rule update needs nested cells, multi-cells have to be flattened every time they get used else where (in the `splitCellToDiagram` function).