### PR TITLE
Fixed "doubleclicking" on Colorpicker

### DIFF
--- a/the-one-true-todey-file-of-cellpond.js
+++ b/the-one-true-todey-file-of-cellpond.js
@@ -6607,7 +6607,7 @@ registerRule(
 				const option = createChild(atom, {...COLOURTODE_PICKER_CHANNEL_OPTION, pityTop, pityBottom})
 				
 				if (oldOptions !== undefined) {
-					option.isGradient = true
+					option.isGradient = oldOptions[i].isGradient
 					option.gradient = oldOptions[i].gradient
 				}
 

--- a/the-one-true-todey-file-of-cellpond.js
+++ b/the-one-true-todey-file-of-cellpond.js
@@ -1025,7 +1025,8 @@ on.load(() => {
 		}
 
 		else if (e.ctrlKey || e.metaKey) {
-			CT_SCALE -= dy * 0.1
+			if (CT_SCALE - dy * 0.1 > 0.05)
+				CT_SCALE -= dy * 0.1
 			const allAtoms = getAllAtoms()
 			for (const atom of allAtoms) {
 				atom.needsColoursUpdate = true

--- a/the-one-true-todey-file-of-cellpond.js
+++ b/the-one-true-todey-file-of-cellpond.js
@@ -4762,6 +4762,9 @@ registerRule(
 					const paddle = atom.highlightedAtom
 					atom.attached = true
 
+					atom.dx = 0
+					atom.dy = 0
+
 					if (atom.highlightedSide === "right") {
 
 						const dummy = createChild(paddle, SLOT, {bottom: true})
@@ -4782,8 +4785,7 @@ registerRule(
 						paddle.cellAtoms.push(atom)
 						atom.x = atom.highlightedAtom.x
 						atom.y = atom.highlightedAtom.y
-						atom.dx = 0
-						atom.dy = 0
+						
 						giveChild(paddle, atom)
 					}
 
@@ -4811,6 +4813,8 @@ registerRule(
 					paddle.cellAtoms.splice(id, 1)
 					atom.x = slot.x
 					atom.y = slot.y
+					atom.dx = 0
+					atom.dy = 0
 
 					atom.attached = true
 					paddle.cellAtoms.push(atom)


### PR DESCRIPTION
Bug: #315 / #345 / #309
Didn't read all the code so hope i got it right.

When you close a colorchannel it saves the atoms to reuse the gradiets. When opening it again it checks if the old atoms are there and it copies the gradient. But it only checks if the atom is there so when you close the channel before it has drawn all gradients, the gradient is undefined but isGradient is true.

I made it that it also copies the isGradient value from the old atom instead of just setting it true.