### PR TITLE
very minor bugfixes

### DIFF
--- a/the-one-true-todey-file-of-cellpond.js
+++ b/the-one-true-todey-file-of-cellpond.js
@@ -1551,8 +1551,9 @@ on.load(() => {
 	const makeNumber = ({values, channel = 0, variable, add, subtract} = {}) => {
 		let numberValues = undefined
 		
-		if (variable !== undefined) {
+		if (variable !== undefined || values === ({}).values) {
 			// placeholder for places in the codebase that don't specify a source!
+			// also placeholder for places in the codebase with empty calls
 			numberValues = [true, true, true, true, true, true, true, true, true, true]
 			//numberValues = [false, false, false, false, false, false, false, false, false, false]
 		}
@@ -2394,7 +2395,7 @@ on.load(() => {
 		}
 
 		if (addend.subtract !== undefined) {
-			results = addChannelToResults(results, addend.add, {source, multiplier: -1, isHue})
+			results = addChannelToResults(results, addend.subtract, {source, multiplier: -1, isHue})
 		}
 		
 		return results


### PR DESCRIPTION
Calling makeNumber() with either no args or an aurgment object with no values key no longer uses the global Object.Prototype.values() function as the values object. (primarily weirdness with invalid json keys cuases this. Or the builtin unused rules.)

Addition and subtraction are entire channel objects with their own addition and subtraction keys, which are supported not by the gui but the backend. However the subtract channel was only being *checked* on inner channels and instead the addition channel was being inversely applied instead when it was present.
