### PR TITLE
Touchscreen interface support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ CellPond has 2 big ideas:<br>
 
 ## How can I use it?
 You can try it out at [cellpond.cool](https://cellpond.cool)<br>
-(sorry no touch controls yet)
 
 Or, you can [download the source code](https://github.com/TodePond/CellPond/archive/refs/heads/main.zip) and open `index.html` in a browser.
 

--- a/index.html
+++ b/index.html
@@ -1,6 +1,7 @@
 <head>
   <title>CellPond</title>
   <!-- 	<link rel="shortcut icon" href=" ready when you are tode-friend! " /> -->
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
   <meta name="twitter:card" content="summary" />
   <meta property="og:title" content="CellPond" />
   <meta property="og:site_name" content="CellPond" />

--- a/libraries/habitat-embed.js
+++ b/libraries/habitat-embed.js
@@ -710,8 +710,27 @@ Habitat.install = (global) => {
 			})
 			
 			global.addEventListener("mousemove", e => {
-				Mouse.position[0] = event.clientX
-				Mouse.position[1] = event.clientY
+				Mouse.position[0] = e.clientX
+				Mouse.position[1] = e.clientY
+			})
+
+			global.addEventListener("touchstart", e => {
+				const touch = e.touches[0]
+				if (!touch) return
+				Mouse.position[0] = touch.clientX
+				Mouse.position[1] = touch.clientY
+				Mouse.Left = true
+			})
+
+			global.addEventListener("touchmove", e => {
+				const touch = e.touches[0]
+				if (!touch) return
+				Mouse.position[0] = touch.clientX
+				Mouse.position[1] = touch.clientY
+			})
+
+			global.addEventListener("touchend", e => {
+				Mouse.Left = false
 			})
 			
 			Reflect.defineProperty(Mouse, "installed", {

--- a/the-one-true-todey-file-of-cellpond.js
+++ b/the-one-true-todey-file-of-cellpond.js
@@ -3682,11 +3682,33 @@ registerRule(
 	{
 		let lastTouchX = 0
 		let lastTouchY = 0
+		let gestureActive = false
+		let lastPinchDist = 0
+		let lastMidX = 0
+		let lastMidY = 0
 
 		on.touchstart(e => {
 			e.preventDefault()
 			const touch = e.touches[0]
 			if (!touch) return
+
+			// Two-finger gesture start
+			if (e.touches.length >= 2) {
+				// Cancel any ongoing single-finger action
+				if (!gestureActive) {
+					if (hand.state.mouseup) hand.state.mouseup({clientX: touch.clientX, clientY: touch.clientY, button: 0})
+				}
+				const t0 = e.touches[0], t1 = e.touches[1]
+				lastPinchDist = Math.hypot(t1.clientX - t0.clientX, t1.clientY - t0.clientY)
+				lastMidX = (t0.clientX + t1.clientX) / 2
+				lastMidY = (t0.clientY + t1.clientY) / 2
+				gestureActive = true
+				return
+			}
+
+			// If gesture was just active, don't start drawing with the remaining finger
+			if (gestureActive) return
+
 			lastTouchX = touch.clientX
 			lastTouchY = touch.clientY
 			hand.isTouch = true
@@ -3719,6 +3741,41 @@ registerRule(
 
 		on.touchmove(e => {
 			e.preventDefault()
+
+			// Two-finger gesture: pan + pinch zoom
+			if (e.touches.length >= 2 && gestureActive) {
+				const t0 = e.touches[0], t1 = e.touches[1]
+				const dist = Math.hypot(t1.clientX - t0.clientX, t1.clientY - t0.clientY)
+				const midX = (t0.clientX + t1.clientX) / 2
+				const midY = (t0.clientY + t1.clientY) / 2
+
+				// Pan: move camera so content follows fingers
+				const dx = midX - lastMidX
+				const dy = midY - lastMidY
+				state.camera.x += dx * DPR / state.camera.scale
+				state.camera.y += dy * DPR / state.camera.scale
+
+				// Pinch zoom: scale by distance ratio, centered on midpoint
+				if (lastPinchDist > 0) {
+					const ratio = dist / lastPinchDist
+					const oldScale = state.camera.scale
+					state.camera.underScale *= ratio
+					state.camera.scale = getNeatScale(state.camera.underScale)
+					const scale = state.camera.scale / oldScale
+					state.camera.x += (1 - scale) * midX * DPR / state.camera.scale
+					state.camera.y += (1 - scale) * midY * DPR / state.camera.scale
+				}
+
+				lastPinchDist = dist
+				lastMidX = midX
+				lastMidY = midY
+				updateImageSize()
+				return
+			}
+
+			// Don't forward single-finger moves during gesture
+			if (gestureActive) return
+
 			const touch = e.touches[0]
 			if (!touch) return
 			const movementX = touch.clientX - lastTouchX
@@ -3732,21 +3789,32 @@ registerRule(
 
 		on.touchend(e => {
 			e.preventDefault()
-			hand.isTouch = false
+
+			// If was gesturing, end gesture when fewer than 2 fingers remain
+			if (gestureActive) {
+				if (e.touches.length < 2) {
+					gestureActive = false
+					// Don't resume drawing — wait for a fresh touchstart
+				}
+				return
+			}
+
 			const touch = e.changedTouches[0]
 			if (!touch) return
 			const upEvent = {clientX: touch.clientX, clientY: touch.clientY, button: 0}
 			if (hand.state.mouseup) hand.state.mouseup(upEvent)
+			hand.isTouch = false
 		}, {passive: false})
 
 		on.touchcancel(e => {
-			hand.isTouch = false
+			gestureActive = false
 			if (hand.state.mouseup) {
 				const touch = e.changedTouches[0]
 				if (touch) {
 					hand.state.mouseup({clientX: touch.clientX, clientY: touch.clientY, button: 0})
 				}
 			}
+			hand.isTouch = false
 		}, {passive: false})
 	}
 

--- a/the-one-true-todey-file-of-cellpond.js
+++ b/the-one-true-todey-file-of-cellpond.js
@@ -1050,6 +1050,7 @@ on.load(() => {
 
 		if (e.altKey) {
 			PADDLE.scroll -= 50 * dy
+			clampPaddleScroll()
 			positionPaddles()
 		}
 
@@ -3436,6 +3437,12 @@ registerRule(
 			if (!hand.content.dragLockX) hand.content.x = (hand.pityStartX + dampen(dx, hand.content.attached && !hand.content.noDampen)) / CT_SCALE * DPR + hand.offset.x
 			if (!hand.content.dragLockY) hand.content.y = (hand.pityStartY + dampen(dy, hand.content.attached && !hand.content.noDampen)) / CT_SCALE * DPR + hand.offset.y
 
+			if (hand.content.isPaddle) {
+				PADDLE.scroll += e.movementY / CT_SCALE * DPR
+				clampPaddleScroll()
+				positionPaddles()
+			}
+
 			hand.content.x = clamp(hand.content.x, hand.content.minX, hand.content.maxX)
 			hand.content.y = clamp(hand.content.y, hand.content.minY, hand.content.maxY)
 
@@ -3582,6 +3589,12 @@ registerRule(
 
 			if (!hand.content.dragLockX) hand.content.x = e.clientX / CT_SCALE * DPR + hand.offset.x
 			if (!hand.content.dragLockY) hand.content.y = e.clientY / CT_SCALE * DPR + hand.offset.y
+
+			if (hand.content.isPaddle) {
+				PADDLE.scroll += e.movementY / CT_SCALE * DPR
+				clampPaddleScroll()
+				positionPaddles()
+			}
 
 			hand.content.x = clamp(hand.content.x, hand.content.minX, hand.content.maxX)
 			hand.content.y = clamp(hand.content.y, hand.content.minY, hand.content.maxY)
@@ -8843,6 +8856,20 @@ registerRule(
 			if (atom.isSquare && atom.expanded) atoms.push(...atom.children)
 		}
 		return atoms
+	}
+
+	const clampPaddleScroll = () => {
+		if (paddles.length === 0) return
+		let totalHeight = 0
+		for (const paddle of paddles) {
+			totalHeight += paddle.height + PADDLE_MARGIN
+		}
+		const screenBottom = innerHeight / CT_SCALE * DPR
+		// Don't push paddles below their default position
+		const maxScroll = 0
+		// Allow scrolling up enough to see the last paddle at the bottom of the screen
+		const minScroll = Math.min(0, (screenBottom - PADDLE.y) - totalHeight)
+		PADDLE.scroll = clamp(PADDLE.scroll, minScroll, maxScroll)
 	}
 
 	const positionPaddles = () => {

--- a/the-one-true-todey-file-of-cellpond.js
+++ b/the-one-true-todey-file-of-cellpond.js
@@ -3692,6 +3692,13 @@ registerRule(
 		let lastMidY = 0
 		let longPressTimer = undefined
 		let deferredTouchStart = undefined
+		let savedBrushSize = undefined
+		const restoreBrushSize = () => {
+			if (savedBrushSize !== undefined) {
+				state.brush.size = savedBrushSize
+				savedBrushSize = undefined
+			}
+		}
 
 		const LONG_PRESS_MS = 500
 
@@ -3752,6 +3759,8 @@ registerRule(
 			lastTouchX = touch.clientX
 			lastTouchY = touch.clientY
 			hand.isTouch = true
+			savedBrushSize = state.brush.size
+			state.brush.size = 0
 
 			clearTimeout(longPressTimer)
 			const lpx = touch.clientX
@@ -3862,6 +3871,7 @@ registerRule(
 					const upEvent = {clientX: touch.clientX, clientY: touch.clientY, button: 0}
 					if (hand.state.mouseup) hand.state.mouseup(upEvent)
 					hand.isTouch = false
+					restoreBrushSize()
 				})
 				return
 			}
@@ -3871,6 +3881,7 @@ registerRule(
 			const upEvent = {clientX: touch.clientX, clientY: touch.clientY, button: 0}
 			if (hand.state.mouseup) hand.state.mouseup(upEvent)
 			hand.isTouch = false
+			restoreBrushSize()
 		}, {passive: false})
 
 		on.touchcancel(e => {
@@ -3884,6 +3895,7 @@ registerRule(
 				}
 			}
 			hand.isTouch = false
+			restoreBrushSize()
 		}, {passive: false})
 	}
 

--- a/the-one-true-todey-file-of-cellpond.js
+++ b/the-one-true-todey-file-of-cellpond.js
@@ -3437,11 +3437,7 @@ registerRule(
 			if (!hand.content.dragLockX) hand.content.x = (hand.pityStartX + dampen(dx, hand.content.attached && !hand.content.noDampen)) / CT_SCALE * DPR + hand.offset.x
 			if (!hand.content.dragLockY) hand.content.y = (hand.pityStartY + dampen(dy, hand.content.attached && !hand.content.noDampen)) / CT_SCALE * DPR + hand.offset.y
 
-			if (hand.content.isPaddle) {
-				PADDLE.scroll += e.movementY / CT_SCALE * DPR
-				clampPaddleScroll()
-				positionPaddles()
-			}
+			if (hand.content.isPaddle) scrollPaddle(e)
 
 			hand.content.x = clamp(hand.content.x, hand.content.minX, hand.content.maxX)
 			hand.content.y = clamp(hand.content.y, hand.content.minY, hand.content.maxY)
@@ -3590,11 +3586,7 @@ registerRule(
 			if (!hand.content.dragLockX) hand.content.x = e.clientX / CT_SCALE * DPR + hand.offset.x
 			if (!hand.content.dragLockY) hand.content.y = e.clientY / CT_SCALE * DPR + hand.offset.y
 
-			if (hand.content.isPaddle) {
-				PADDLE.scroll += e.movementY / CT_SCALE * DPR
-				clampPaddleScroll()
-				positionPaddles()
-			}
+			if (hand.content.isPaddle) scrollPaddle(e)
 
 			hand.content.x = clamp(hand.content.x, hand.content.minX, hand.content.maxX)
 			hand.content.y = clamp(hand.content.y, hand.content.minY, hand.content.maxY)
@@ -3701,6 +3693,24 @@ registerRule(
 		let longPressTimer = undefined
 		let deferredTouchStart = undefined
 
+		const LONG_PRESS_MS = 500
+
+		const startLongPress = (lpx, lpy) => {
+			longPressTimer = setTimeout(() => {
+				longPressTimer = undefined
+				deferredTouchStart = undefined
+				const cell = pickCell(...getCursorView(lpx, lpy))
+				if (cell !== undefined) {
+					setBrushColour(cell.colour)
+				} else {
+					brushColourCycleIndex++
+					if (brushColourCycleIndex >= brushColourCycle.length) brushColourCycleIndex = 0
+					setBrushColour(brushColourCycle[brushColourCycleIndex])
+				}
+				squareTool.toolbarNeedsColourUpdate = true
+			}, LONG_PRESS_MS)
+		}
+
 		on.touchstart(e => {
 			e.preventDefault()
 			const touch = e.touches[0]
@@ -3744,19 +3754,7 @@ registerRule(
 					hand.touchButton = 0
 					changeHandState(HAND.TOUCHING)
 				}
-				longPressTimer = setTimeout(() => {
-					longPressTimer = undefined
-					deferredTouchStart = undefined
-					const cell = pickCell(...getCursorView(lpx, lpy))
-					if (cell !== undefined) {
-						setBrushColour(cell.colour)
-					} else {
-						brushColourCycleIndex++
-						if (brushColourCycleIndex >= brushColourCycle.length) brushColourCycleIndex = 0
-						setBrushColour(brushColourCycle[brushColourCycleIndex])
-					}
-					squareTool.toolbarNeedsColourUpdate = true
-				}, 500)
+				startLongPress(lpx, lpy)
 			} else {
 				deferredTouchStart = () => {
 					Mouse.Left = false
@@ -3768,19 +3766,7 @@ registerRule(
 					const downEvent = {clientX: lpx, clientY: lpy, button: 0}
 					if (hand.state.mousedown) hand.state.mousedown(downEvent)
 				}
-				longPressTimer = setTimeout(() => {
-					longPressTimer = undefined
-					deferredTouchStart = undefined
-					const cell = pickCell(...getCursorView(lpx, lpy))
-					if (cell !== undefined) {
-						setBrushColour(cell.colour)
-					} else {
-						brushColourCycleIndex++
-						if (brushColourCycleIndex >= brushColourCycle.length) brushColourCycleIndex = 0
-						setBrushColour(brushColourCycle[brushColourCycleIndex])
-					}
-					squareTool.toolbarNeedsColourUpdate = true
-				}, 500)
+				startLongPress(lpx, lpy)
 			}
 		}, {passive: false})
 
@@ -8909,6 +8895,12 @@ registerRule(
 			if (atom.isSquare && atom.expanded) atoms.push(...atom.children)
 		}
 		return atoms
+	}
+
+	const scrollPaddle = (e) => {
+		PADDLE.scroll += e.movementY / CT_SCALE * DPR
+		clampPaddleScroll()
+		positionPaddles()
 	}
 
 	const clampPaddleScroll = () => {

--- a/the-one-true-todey-file-of-cellpond.js
+++ b/the-one-true-todey-file-of-cellpond.js
@@ -3858,6 +3858,10 @@ registerRule(
 			if (gestureActive) {
 				if (e.touches.length < 2) {
 					gestureActive = false
+					deferredTouchStart = undefined
+					Mouse.Left = false
+					hand.isTouch = false
+					restoreBrushSize()
 				}
 				return
 			}
@@ -3870,6 +3874,7 @@ registerRule(
 				requestAnimationFrame(() => {
 					const upEvent = {clientX: touch.clientX, clientY: touch.clientY, button: 0}
 					if (hand.state.mouseup) hand.state.mouseup(upEvent)
+					Mouse.Left = false
 					hand.isTouch = false
 					restoreBrushSize()
 				})
@@ -3880,6 +3885,7 @@ registerRule(
 			if (!touch) return
 			const upEvent = {clientX: touch.clientX, clientY: touch.clientY, button: 0}
 			if (hand.state.mouseup) hand.state.mouseup(upEvent)
+			Mouse.Left = false
 			hand.isTouch = false
 			restoreBrushSize()
 		}, {passive: false})
@@ -3894,6 +3900,7 @@ registerRule(
 					hand.state.mouseup({clientX: touch.clientX, clientY: touch.clientY, button: 0})
 				}
 			}
+			Mouse.Left = false
 			hand.isTouch = false
 			restoreBrushSize()
 		}, {passive: false})

--- a/the-one-true-todey-file-of-cellpond.js
+++ b/the-one-true-todey-file-of-cellpond.js
@@ -3962,7 +3962,7 @@ registerRule(
 		grabbed.dx = 0
 		grabbed.dy = 0
 
-		if (atom.stayAtBack) bringAtomToBack(grabbed)
+		if (grabbed.stayAtBack) bringAtomToBack(grabbed)
 		else bringAtomToFront(grabbed)
 
 		return grabbed
@@ -8905,6 +8905,7 @@ registerRule(
 		paddles.push(paddle)
 		positionPaddles()
 		registerAtom(paddle)
+		bringAtomToBack(paddle)
 		return paddle
 	}
 

--- a/the-one-true-todey-file-of-cellpond.js
+++ b/the-one-true-todey-file-of-cellpond.js
@@ -3698,6 +3698,8 @@ registerRule(
 		let lastPinchDist = 0
 		let lastMidX = 0
 		let lastMidY = 0
+		let longPressTimer = undefined
+		let deferredTouchStart = undefined
 
 		on.touchstart(e => {
 			e.preventDefault()
@@ -3705,6 +3707,8 @@ registerRule(
 			if (!touch) return
 
 			if (e.touches.length >= 2) {
+				clearTimeout(longPressTimer)
+				longPressTimer = undefined
 				if (!gestureActive) {
 					if (hand.state.mouseup) hand.state.mouseup({clientX: touch.clientX, clientY: touch.clientY, button: 0})
 				}
@@ -3722,29 +3726,62 @@ registerRule(
 			lastTouchY = touch.clientY
 			hand.isTouch = true
 
+			clearTimeout(longPressTimer)
+			const lpx = touch.clientX
+			const lpy = touch.clientY
+
 			const x = touch.clientX / CT_SCALE
 			const y = touch.clientY / CT_SCALE
 			const atom = getAtom(x, y)
 
 			if (atom !== undefined && atom.grabbable) {
-				grabAtom(atom, x, y)
-				hand.pityStartX = touch.clientX
-				hand.pityStartY = touch.clientY
-				hand.pityStartT = 0
-				hand.hasStartedDragging = false
-				hand.touchButton = 0
-				changeHandState(HAND.TOUCHING)
-				return
+				deferredTouchStart = () => {
+					grabAtom(atom, x, y)
+					hand.pityStartX = lpx
+					hand.pityStartY = lpy
+					hand.pityStartT = 0
+					hand.hasStartedDragging = false
+					hand.touchButton = 0
+					changeHandState(HAND.TOUCHING)
+				}
+				longPressTimer = setTimeout(() => {
+					longPressTimer = undefined
+					deferredTouchStart = undefined
+					const cell = pickCell(...getCursorView(lpx, lpy))
+					if (cell !== undefined) {
+						setBrushColour(cell.colour)
+					} else {
+						brushColourCycleIndex++
+						if (brushColourCycleIndex >= brushColourCycle.length) brushColourCycleIndex = 0
+						setBrushColour(brushColourCycle[brushColourCycleIndex])
+					}
+					squareTool.toolbarNeedsColourUpdate = true
+				}, 500)
+			} else {
+				deferredTouchStart = () => {
+					Mouse.Left = false
+					const moveEvent = {clientX: lpx, clientY: lpy, movementX: 0, movementY: 0, button: 0}
+					if (hand.state.mousemove) hand.state.mousemove(moveEvent)
+					state.cursor.previous.x = lpx
+					state.cursor.previous.y = lpy
+					Mouse.Left = true
+					const downEvent = {clientX: lpx, clientY: lpy, button: 0}
+					if (hand.state.mousedown) hand.state.mousedown(downEvent)
+				}
+				longPressTimer = setTimeout(() => {
+					longPressTimer = undefined
+					deferredTouchStart = undefined
+					const cell = pickCell(...getCursorView(lpx, lpy))
+					if (cell !== undefined) {
+						setBrushColour(cell.colour)
+					} else {
+						brushColourCycleIndex++
+						if (brushColourCycleIndex >= brushColourCycle.length) brushColourCycleIndex = 0
+						setBrushColour(brushColourCycle[brushColourCycleIndex])
+					}
+					squareTool.toolbarNeedsColourUpdate = true
+				}, 500)
 			}
-
-			Mouse.Left = false
-			const moveEvent = {clientX: touch.clientX, clientY: touch.clientY, movementX: 0, movementY: 0, button: 0}
-			if (hand.state.mousemove) hand.state.mousemove(moveEvent)
-			state.cursor.previous.x = touch.clientX
-			state.cursor.previous.y = touch.clientY
-			Mouse.Left = true
-			const downEvent = {clientX: touch.clientX, clientY: touch.clientY, button: 0}
-			if (hand.state.mousedown) hand.state.mousedown(downEvent)
 		}, {passive: false})
 
 		on.touchmove(e => {
@@ -3780,6 +3817,16 @@ registerRule(
 
 			if (gestureActive) return
 
+			if (longPressTimer !== undefined) {
+				clearTimeout(longPressTimer)
+				longPressTimer = undefined
+			}
+
+			if (deferredTouchStart !== undefined) {
+				deferredTouchStart()
+				deferredTouchStart = undefined
+			}
+
 			const touch = e.touches[0]
 			if (!touch) return
 			const movementX = touch.clientX - lastTouchX
@@ -3793,11 +3840,26 @@ registerRule(
 
 		on.touchend(e => {
 			e.preventDefault()
+			clearTimeout(longPressTimer)
+			longPressTimer = undefined
 
 			if (gestureActive) {
 				if (e.touches.length < 2) {
 					gestureActive = false
 				}
+				return
+			}
+
+			if (deferredTouchStart !== undefined) {
+				deferredTouchStart()
+				deferredTouchStart = undefined
+				const touch = e.changedTouches[0]
+				if (!touch) return
+				requestAnimationFrame(() => {
+					const upEvent = {clientX: touch.clientX, clientY: touch.clientY, button: 0}
+					if (hand.state.mouseup) hand.state.mouseup(upEvent)
+					hand.isTouch = false
+				})
 				return
 			}
 
@@ -3809,6 +3871,8 @@ registerRule(
 		}, {passive: false})
 
 		on.touchcancel(e => {
+			clearTimeout(longPressTimer)
+			longPressTimer = undefined
 			gestureActive = false
 			if (hand.state.mouseup) {
 				const touch = e.changedTouches[0]

--- a/the-one-true-todey-file-of-cellpond.js
+++ b/the-one-true-todey-file-of-cellpond.js
@@ -3695,10 +3695,27 @@ registerRule(
 
 		const LONG_PRESS_MS = 500
 
-		const startLongPress = (lpx, lpy) => {
+		const startLongPress = (lpx, lpy, atom) => {
 			longPressTimer = setTimeout(() => {
 				longPressTimer = undefined
 				deferredTouchStart = undefined
+
+				if (atom !== undefined && atom.rightDraggable) {
+					const x = lpx / CT_SCALE
+					const y = lpy / CT_SCALE
+					grabAtom(atom, x, y)
+					hand.content = hand.content.rightDrag(hand.content, x, y)
+					hand.pityStartX = lpx
+					hand.pityStartY = lpy
+					hand.pityStartT = 0
+					hand.hasStartedDragging = true
+					hand.touchButton = 0
+					hand.content.x = lpx / CT_SCALE * DPR + hand.offset.x
+					hand.content.y = lpy / CT_SCALE * DPR + hand.offset.y
+					changeHandState(HAND.DRAGGING)
+					return
+				}
+
 				const cell = pickCell(...getCursorView(lpx, lpy))
 				if (cell !== undefined) {
 					setBrushColour(cell.colour)
@@ -3754,7 +3771,7 @@ registerRule(
 					hand.touchButton = 0
 					changeHandState(HAND.TOUCHING)
 				}
-				startLongPress(lpx, lpy)
+				startLongPress(lpx, lpy, atom)
 			} else {
 				deferredTouchStart = () => {
 					Mouse.Left = false

--- a/the-one-true-todey-file-of-cellpond.js
+++ b/the-one-true-todey-file-of-cellpond.js
@@ -469,6 +469,7 @@ on.load(() => {
 	const show = Show.start({paused: false, scale: DPR})
 	const {context, canvas} = show
 	canvas.style["position"] = "absolute"
+	canvas.style["touch-action"] = "none"
 	
 	//===============//
 	// IMAGE + SIZES //
@@ -2989,7 +2990,9 @@ registerRule(
 	//colourTodeCanvas.style["image-rendering"] = "pixelated"
 	colourTodeCanvas.style["position"] = "absolute"
 	colourTodeCanvas.style["top"] = "0px"
-	
+	colourTodeCanvas.style["touch-action"] = "none"
+	document.body.style["touch-action"] = "none"
+
 	document.body.append(colourTodeCanvas)
 
 	on.resize(() => {
@@ -3436,14 +3439,16 @@ registerRule(
 			hand.content.x = clamp(hand.content.x, hand.content.minX, hand.content.maxX)
 			hand.content.y = clamp(hand.content.y, hand.content.minY, hand.content.maxY)
 
-			if (distanceFromPityStart < pity) {
-				return
-			}
+			if (!hand.isTouch) {
+				if (distanceFromPityStart < pity) {
+					return
+				}
 
-			const timeSincePityStart = Date.now() - hand.pityStartT
-			if (timeSincePityStart < DRAG_PITY_TIME) {
-				const handSpeed = Math.hypot(hand.velocity.x, hand.velocity.y)
-				if (handSpeed <= DRAG_UNPITY_SPEED) return
+				const timeSincePityStart = Date.now() - hand.pityStartT
+				if (timeSincePityStart < DRAG_PITY_TIME) {
+					const handSpeed = Math.hypot(hand.velocity.x, hand.velocity.y)
+					if (handSpeed <= DRAG_UNPITY_SPEED) return
+				}
 			}
 
 			if (!hand.content.dragLockX) hand.content.x = hand.pityStartX / CT_SCALE * DPR + hand.offset.x
@@ -3656,19 +3661,94 @@ registerRule(
 		hand.state = state
 	}
 
-	on.mousemove(e => hand.state.mousemove? hand.state.mousemove(e) : undefined)
+	on.mousemove(e => {
+		if (hand.isTouch) return
+		if (hand.state.mousemove) hand.state.mousemove(e)
+	})
 	on.mousedown(e => {
-
+		if (hand.isTouch) return
 		if (e.button === 0) if (hand.state.mousedown) hand.state.mousedown(e)
 		if (e.button === 1) if (hand.state.middlemousedown) hand.state.middlemousedown(e)
 		if (e.button === 2) if (hand.state.rightmousedown) hand.state.rightmousedown(e)
 	})
 	on.mouseup(e => {
+		if (hand.isTouch) return
 		if (e.button === 0) if (hand.state.mouseup) hand.state.mouseup(e)
 		if (e.button === 1) if (hand.state.middlemouseup) hand.state.middlemouseup(e)
 		if (e.button === 2) if (hand.state.rightmouseup) hand.state.rightmouseup(e)
-		
 	})
+
+	// Touch-to-mouse shim
+	{
+		let lastTouchX = 0
+		let lastTouchY = 0
+
+		on.touchstart(e => {
+			e.preventDefault()
+			const touch = e.touches[0]
+			if (!touch) return
+			lastTouchX = touch.clientX
+			lastTouchY = touch.clientY
+			hand.isTouch = true
+
+			const x = touch.clientX / CT_SCALE
+			const y = touch.clientY / CT_SCALE
+			const atom = getAtom(x, y)
+
+			if (atom !== undefined && atom.grabbable) {
+				grabAtom(atom, x, y)
+				hand.pityStartX = touch.clientX
+				hand.pityStartY = touch.clientY
+				hand.pityStartT = 0
+				hand.hasStartedDragging = false
+				hand.touchButton = 0
+				changeHandState(HAND.TOUCHING)
+				return
+			}
+
+			// No atom — fall back to brush/void via synthetic events
+			Mouse.Left = false
+			const moveEvent = {clientX: touch.clientX, clientY: touch.clientY, movementX: 0, movementY: 0, button: 0}
+			if (hand.state.mousemove) hand.state.mousemove(moveEvent)
+			state.cursor.previous.x = touch.clientX
+			state.cursor.previous.y = touch.clientY
+			Mouse.Left = true
+			const downEvent = {clientX: touch.clientX, clientY: touch.clientY, button: 0}
+			if (hand.state.mousedown) hand.state.mousedown(downEvent)
+		}, {passive: false})
+
+		on.touchmove(e => {
+			e.preventDefault()
+			const touch = e.touches[0]
+			if (!touch) return
+			const movementX = touch.clientX - lastTouchX
+			const movementY = touch.clientY - lastTouchY
+			lastTouchX = touch.clientX
+			lastTouchY = touch.clientY
+
+			const moveEvent = {clientX: touch.clientX, clientY: touch.clientY, movementX, movementY, button: 0}
+			if (hand.state.mousemove) hand.state.mousemove(moveEvent)
+		}, {passive: false})
+
+		on.touchend(e => {
+			e.preventDefault()
+			hand.isTouch = false
+			const touch = e.changedTouches[0]
+			if (!touch) return
+			const upEvent = {clientX: touch.clientX, clientY: touch.clientY, button: 0}
+			if (hand.state.mouseup) hand.state.mouseup(upEvent)
+		}, {passive: false})
+
+		on.touchcancel(e => {
+			hand.isTouch = false
+			if (hand.state.mouseup) {
+				const touch = e.changedTouches[0]
+				if (touch) {
+					hand.state.mouseup({clientX: touch.clientX, clientY: touch.clientY, button: 0})
+				}
+			}
+		}, {passive: false})
+	}
 
 	hand.state = HAND.FREE
 
@@ -8758,16 +8838,14 @@ registerRule(
 		x: -PADDLE.x,
 		y: PADDLE.size/2 - PADDLE.x/2,
 		touch: (atom) => atom.parent.pinhole,
-		grab: (atom) => {
-			//if (atom.parent.pinhole.locked) return 
-			return atom.parent.pinhole
-		},
+		grab: (atom) => atom.parent,
 	}
 
 	const PIN_HOLE = {
 		isPinhole: true,
 		attached: true,
 		locked: false,
+		grab: (atom) => atom.parent.parent,
 		borderScale: 1/2,
 		borderColour: Colour.Black,
 		draw: (atom) => {

--- a/the-one-true-todey-file-of-cellpond.js
+++ b/the-one-true-todey-file-of-cellpond.js
@@ -8848,14 +8848,20 @@ registerRule(
 	}
 
 	const clampPaddleScroll = () => {
-		if (paddles.length === 0) return
+		if (paddles.length < 3) {
+			PADDLE.scroll = 0
+			return
+		}
 		let totalHeight = 0
 		for (const paddle of paddles) {
 			totalHeight += paddle.height + PADDLE_MARGIN
 		}
-		const screenBottom = innerHeight / CT_SCALE * DPR
+		let lastTwoHeight = 0
+		for (let i = paddles.length - 1; i >= paddles.length - 2; i--) {
+			lastTwoHeight += paddles[i].height + PADDLE_MARGIN
+		}
 		const maxScroll = 0
-		const minScroll = Math.min(0, (screenBottom - PADDLE.y) - totalHeight)
+		const minScroll = -(totalHeight - lastTwoHeight)
 		PADDLE.scroll = clamp(PADDLE.scroll, minScroll, maxScroll)
 	}
 

--- a/the-one-true-todey-file-of-cellpond.js
+++ b/the-one-true-todey-file-of-cellpond.js
@@ -3691,7 +3691,6 @@ registerRule(
 		if (e.button === 2) if (hand.state.rightmouseup) hand.state.rightmouseup(e)
 	})
 
-	// Touch-to-mouse shim
 	{
 		let lastTouchX = 0
 		let lastTouchY = 0
@@ -3705,9 +3704,7 @@ registerRule(
 			const touch = e.touches[0]
 			if (!touch) return
 
-			// Two-finger gesture start
 			if (e.touches.length >= 2) {
-				// Cancel any ongoing single-finger action
 				if (!gestureActive) {
 					if (hand.state.mouseup) hand.state.mouseup({clientX: touch.clientX, clientY: touch.clientY, button: 0})
 				}
@@ -3719,7 +3716,6 @@ registerRule(
 				return
 			}
 
-			// If gesture was just active, don't start drawing with the remaining finger
 			if (gestureActive) return
 
 			lastTouchX = touch.clientX
@@ -3741,7 +3737,6 @@ registerRule(
 				return
 			}
 
-			// No atom — fall back to brush/void via synthetic events
 			Mouse.Left = false
 			const moveEvent = {clientX: touch.clientX, clientY: touch.clientY, movementX: 0, movementY: 0, button: 0}
 			if (hand.state.mousemove) hand.state.mousemove(moveEvent)
@@ -3755,20 +3750,17 @@ registerRule(
 		on.touchmove(e => {
 			e.preventDefault()
 
-			// Two-finger gesture: pan + pinch zoom
 			if (e.touches.length >= 2 && gestureActive) {
 				const t0 = e.touches[0], t1 = e.touches[1]
 				const dist = Math.hypot(t1.clientX - t0.clientX, t1.clientY - t0.clientY)
 				const midX = (t0.clientX + t1.clientX) / 2
 				const midY = (t0.clientY + t1.clientY) / 2
 
-				// Pan: move camera so content follows fingers
 				const dx = midX - lastMidX
 				const dy = midY - lastMidY
 				state.camera.x += dx * DPR / state.camera.scale
 				state.camera.y += dy * DPR / state.camera.scale
 
-				// Pinch zoom: scale by distance ratio, centered on midpoint
 				if (lastPinchDist > 0) {
 					const ratio = dist / lastPinchDist
 					const oldScale = state.camera.scale
@@ -3786,7 +3778,6 @@ registerRule(
 				return
 			}
 
-			// Don't forward single-finger moves during gesture
 			if (gestureActive) return
 
 			const touch = e.touches[0]
@@ -3803,11 +3794,9 @@ registerRule(
 		on.touchend(e => {
 			e.preventDefault()
 
-			// If was gesturing, end gesture when fewer than 2 fingers remain
 			if (gestureActive) {
 				if (e.touches.length < 2) {
 					gestureActive = false
-					// Don't resume drawing — wait for a fresh touchstart
 				}
 				return
 			}
@@ -8865,9 +8854,7 @@ registerRule(
 			totalHeight += paddle.height + PADDLE_MARGIN
 		}
 		const screenBottom = innerHeight / CT_SCALE * DPR
-		// Don't push paddles below their default position
 		const maxScroll = 0
-		// Allow scrolling up enough to see the last paddle at the bottom of the screen
 		const minScroll = Math.min(0, (screenBottom - PADDLE.y) - totalHeight)
 		PADDLE.scroll = clamp(PADDLE.scroll, minScroll, maxScroll)
 	}


### PR DESCRIPTION
Hi Lu, I watched your [SPATIAL PROGRAMMING WITHOUT ESCAPE](https://www.youtube.com/watch?v=eQgxFuw8f1U) video today and was totally captivated!

I saw in the readme that there wasn't touch support. So I figured I'd add it. Everything works as expected as far as I can tell, and you can multitouch with two fingers to pinch-zoom and pan around the grid. Long pressing >500 ms works like right clicking, to either sample a color in the grid, or generate a random one outside of it, or create a new combined atom from the paddle area, or clone new atoms from existing ones. No comments since the rest of the file doesn't have them, but would be happy to document this better if you'd like. This closes https://github.com/TodePond/CellPond/issues/86.

The one behavior that needed to be changed/added was moving the paddles up and down by clicking and dragging them, rather than only with alt-scroll. But that's in too, and it works nicely I think. Scrolling unlocks once you have more than 2 paddles, and is clamped so you can't lose them offscreen. That helps with the scrolling bit of https://github.com/TodePond/CellPond/issues/101, closes https://github.com/TodePond/CellPond/issues/53, and I also ran into https://github.com/TodePond/CellPond/issues/159 which I think should be fixed now by making sure paddles are at the bottom.

I also couldn't immediately think of a way to nicely change the brush size with touch only, so touches are forced to a size 0 brush.

I tested everything on my Windows touchscreen laptop running Firefox and on my iPhone running safari, and things seem to work well both places.

Pleased to have joined the ritual!

_ribbit_